### PR TITLE
Refactor GPU references and enable nullable

### DIFF
--- a/BAVCL/BAVCL.csproj
+++ b/BAVCL/BAVCL.csproj
@@ -2,14 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BAVCL/Core/Exceptions/KernelNotCompiledException.cs
+++ b/BAVCL/Core/Exceptions/KernelNotCompiledException.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace BAVCL.Core.Exceptions;
+
+public class KernelNotCompiledException(string kernelName) : Exception(
+$"Kernel: '{kernelName}' not compiled. Ensure that it has been compiled before use.")
+{ }

--- a/BAVCL/Core/GPU/GPU.cs
+++ b/BAVCL/Core/GPU/GPU.cs
@@ -1,91 +1,27 @@
-﻿using ILGPU;
-using ILGPU.Runtime;
+﻿using ILGPU.Runtime;
 using System;
-using System.Collections.Generic;
 using BAVCL.Core.Interfaces;
 using BAVCL.Core;
 
-namespace BAVCL
+namespace BAVCL;
+
+public sealed partial class GPU(Accelerator accelerator, IMemoryManager memoryManager) : IDisposable
 {
-	public partial class GPU
-	{
-		protected internal Context context;
-		public Accelerator accelerator;
-		public AcceleratorStream DefaultStream => accelerator.DefaultStream;
-		public void Synchronize() => accelerator.Synchronize();
-		private IMemoryManager memoryManager;
-		
-		// Accelerator Preference Order
-		Dictionary<AcceleratorType, int> AcceleratorPrefOrder = new()
-		{
-			{ AcceleratorType.Cuda, 2 },
-			{ AcceleratorType.OpenCL, 1 },
-			{ AcceleratorType.CPU, 0 }
-		};
+	private readonly IMemoryManager _memoryManager = memoryManager;
+	public Accelerator accelerator = accelerator;
+	internal AcceleratorStream _defaultStream => accelerator.DefaultStream;
+	internal void Synchronize() => accelerator.Synchronize();
 
-		// Constructor
-		public GPU(float memorycap = 0.8f, bool forceCPU = false)
-		{
-			// Create Context
-			context = Context.Create(builder => builder.Default().EnableAlgorithms());
-			// OptimizationLevel optimizationLevel = OptimizationLevel.Debug
+	// Wrappers for Memory Manager
+	public (uint, MemoryBuffer) Allocate<T>(ICacheable<T> cacheable) where T : unmanaged => _memoryManager.Allocate(cacheable, accelerator);
+	public (uint, MemoryBuffer) Allocate<T>(ICacheable cacheable, T[] values) where T : unmanaged => _memoryManager.Allocate(cacheable, values, accelerator);
+	public (uint, MemoryBuffer) AllocateEmpty<T>(ICacheable cacheable, int length) where T : unmanaged => _memoryManager.AllocateEmpty<T>(cacheable, length, accelerator);
+	public MemoryBuffer? TryGetBuffer<T>(uint Id) where T : unmanaged => _memoryManager.GetBuffer(Id);
+	public (uint, MemoryBuffer) UpdateBuffer<T>(ICacheable cacheable, T[] values) where T : unmanaged => _memoryManager.UpdateBuffer(cacheable, values, accelerator);
+	public (uint, MemoryBuffer) UpdateBuffer<T>(ICacheable<T> cacheable) where T : unmanaged => _memoryManager.UpdateBuffer(cacheable, accelerator);
+	public uint GCItem(uint Id) => _memoryManager.GCItem(Id);
+	public string PrintMemoryUsage(bool percentage, string format = "F2") => _memoryManager.PrintMemoryUsage(percentage, format);
+	public string GetMemUsage() => _memoryManager.MemoryUsed.ToString();
 
-			// Get Accelerator Device
-			//this.accelerator = context.GetPreferredDevice(preferCPU: forceCPU).CreateAccelerator(context);
-			accelerator = GetPreferedAccelerator(context, forceCPU);
-			Console.WriteLine($"Device loaded: {accelerator.Name}");
-
-			// Set Memory Usage Cap
-			memoryManager = new LRU(accelerator.MemorySize, memorycap);
-
-			// Load Kernels
-			LoadKernels();
-		}
-
-		// Wrappers for Memory Manager
-		public (uint, MemoryBuffer) Allocate<T>(ICacheable<T> cacheable) where T : unmanaged => memoryManager.Allocate(cacheable, accelerator);
-		public (uint, MemoryBuffer) Allocate<T>(ICacheable cacheable, T[] values) where T : unmanaged => memoryManager.Allocate(cacheable, values, accelerator);
-		public (uint, MemoryBuffer) AllocateEmpty<T>(ICacheable cacheable, int length) where T : unmanaged => memoryManager.AllocateEmpty<T>(cacheable, length, accelerator);
-		public MemoryBuffer TryGetBuffer<T>(uint Id) where T : unmanaged => memoryManager.GetBuffer(Id);
-		public (uint, MemoryBuffer) UpdateBuffer<T>(ICacheable cacheable, T[] values) where T : unmanaged => memoryManager.UpdateBuffer(cacheable, values, accelerator);
-		public (uint, MemoryBuffer) UpdateBuffer<T>(ICacheable<T> cacheable) where T : unmanaged => memoryManager.UpdateBuffer(cacheable, accelerator);
-		public uint GCItem(uint Id) => memoryManager.GCItem(Id);
-		public string PrintMemoryUsage(bool percentage, string format = "F2") => memoryManager.PrintMemoryUsage(percentage, format);
-		public string GetMemUsage() => memoryManager.MemoryUsed.ToString();
-
-		private Accelerator GetPreferedAccelerator(Context context, bool forceCPU)
-		{
-			var devices = context.Devices;
-
-			if (devices.Length == 0) throw new Exception("No Accelerators");
-
-			Device preferedAccelerator = null;
-			for (int i = 0; i < devices.Length; i++)
-			{
-				if (forceCPU && devices[i].AcceleratorType == AcceleratorType.CPU)
-					return devices[i].CreateAccelerator(context);
-				
-				if (preferedAccelerator == null)
-					preferedAccelerator = devices[i];
-
-				if (AcceleratorPrefOrder.TryGetValue(preferedAccelerator.AcceleratorType, out int Prefpriority))
-					if (AcceleratorPrefOrder.TryGetValue(devices[i].AcceleratorType, out int Devicepriority))
-					{
-						if (Devicepriority > Prefpriority)
-						{
-							preferedAccelerator = devices[i];
-							continue;
-						}
-
-						if (devices[i].MaxConstantMemory > preferedAccelerator.MaxConstantMemory)
-						{
-							preferedAccelerator = devices[i];
-							continue;
-						}
-					}
-			}
-			return preferedAccelerator.CreateAccelerator(context);
-		}
-	
-	}
+	public void Dispose() => accelerator.Dispose();
 }

--- a/BAVCL/Core/GPU/GPU.cs
+++ b/BAVCL/Core/GPU/GPU.cs
@@ -9,7 +9,7 @@ public sealed partial class GPU(Accelerator accelerator, IMemoryManager memoryMa
 {
 	private readonly IMemoryManager _memoryManager = memoryManager;
 	public Accelerator accelerator = accelerator;
-	internal AcceleratorStream _defaultStream => accelerator.DefaultStream;
+	internal AcceleratorStream DefaultStream => accelerator.DefaultStream;
 	internal void Synchronize() => accelerator.Synchronize();
 
 	// Wrappers for Memory Manager

--- a/BAVCL/Core/GPU/Kernels/kernels.cs
+++ b/BAVCL/Core/GPU/Kernels/kernels.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using BAVCL.Core.Exceptions;
 using BAVCL.Experimental;
 using ILGPU;
 using ILGPU.Algorithms;
@@ -10,30 +11,48 @@ namespace BAVCL
 	public partial class GPU
 	{
 		// TEST KERNELS
-		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>> TestSQRTKernel;
-		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>> TestMYSQRTKernel;
-		
-		// CORE KERNELS
-		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>, ArrayView<float>, int, int> appendKernel;
-		public Action<AcceleratorStream, Index1D, ArrayView<float>, float> nanToNumKernel;
-		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>, ArrayView<int>> getSliceKernel;
-		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>, ArrayView<float>, SpecializedValue<int>> a_opFKernel;
-		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>, float, SpecializedValue<int>> s_opFKernel;
-		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>, ArrayView<float>, int, SpecializedValue<int>> vectormatrixOpKernel;
+		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>> TestSQRTKernel
+			= (_, _, _, _) => throw new KernelNotCompiledException(nameof(TestSQRTKernel));
+		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>> TestMYSQRTKernel
+			= (_, _, _, _) => throw new KernelNotCompiledException(nameof(TestMYSQRTKernel));
 
-		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>, SpecializedValue<int>> a_FloatOPKernelIP;
-		public Action<AcceleratorStream, Index1D, ArrayView<float>, float, SpecializedValue<int>> s_FloatOPKernelIP;
-		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>> diffKernel;
-		public Action<AcceleratorStream, Index1D, ArrayView<float>> reverseKernel;
-		public Action<AcceleratorStream, Index1D, ArrayView<float>> absKernel;
-		public Action<AcceleratorStream, Index1D, ArrayView<float>> rcpKernel;
-		public Action<AcceleratorStream, Index1D, ArrayView<float>> rsqrtKernel;
-		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>, ArrayView<float>> crossKernel;
-		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>, int> transposekernel;
-		public Action<AcceleratorStream, Index1D, ArrayView<float>, float> LogKernel;
-		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>, ArrayView<float>, int, SpecializedValue<int>> simdVectorKernel;
-		
-		
+		// CORE KERNELS
+		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>, ArrayView<float>, int, int> appendKernel
+			= (_, _, _, _, _, _, _) => throw new KernelNotCompiledException(nameof(appendKernel));
+		public Action<AcceleratorStream, Index1D, ArrayView<float>, float> nanToNumKernel
+			= (_, _, _, _) => throw new KernelNotCompiledException(nameof(nanToNumKernel));
+		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>, ArrayView<int>> getSliceKernel
+			= (_, _, _, _, _) => throw new KernelNotCompiledException(nameof(getSliceKernel));
+		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>, ArrayView<float>, SpecializedValue<int>> a_opFKernel
+			= (_, _, _, _, _, _) => throw new KernelNotCompiledException(nameof(a_opFKernel));
+		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>, float, SpecializedValue<int>> s_opFKernel
+			= (_, _, _, _, _, _) => throw new KernelNotCompiledException(nameof(s_opFKernel));
+		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>, ArrayView<float>, int, SpecializedValue<int>> vectormatrixOpKernel
+			= (_, _, _, _, _, _, _) => throw new KernelNotCompiledException(nameof(vectormatrixOpKernel));
+
+		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>, SpecializedValue<int>> a_FloatOPKernelIP
+			= (_, _, _, _, _) => throw new KernelNotCompiledException(nameof(a_FloatOPKernelIP));
+		public Action<AcceleratorStream, Index1D, ArrayView<float>, float, SpecializedValue<int>> s_FloatOPKernelIP
+			= (_, _, _, _, _) => throw new KernelNotCompiledException(nameof(s_FloatOPKernelIP));
+		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>> diffKernel
+			= (_, _, _, _) => throw new KernelNotCompiledException(nameof(diffKernel));
+		public Action<AcceleratorStream, Index1D, ArrayView<float>> reverseKernel
+			= (_, _, _) => throw new KernelNotCompiledException(nameof(reverseKernel));
+		public Action<AcceleratorStream, Index1D, ArrayView<float>> absKernel
+			= (_, _, _) => throw new KernelNotCompiledException(nameof(absKernel));
+		public Action<AcceleratorStream, Index1D, ArrayView<float>> rcpKernel
+			= (_, _, _) => throw new KernelNotCompiledException(nameof(rcpKernel));
+		public Action<AcceleratorStream, Index1D, ArrayView<float>> rsqrtKernel
+			= (_, _, _) => throw new KernelNotCompiledException(nameof(rsqrtKernel));
+		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>, ArrayView<float>> crossKernel
+			= (_, _, _, _, _) => throw new KernelNotCompiledException(nameof(crossKernel));
+		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>, int> transposekernel
+			= (_, _, _, _, _) => throw new KernelNotCompiledException(nameof(transposekernel));
+		public Action<AcceleratorStream, Index1D, ArrayView<float>, float> LogKernel
+			= (_, _, _, _) => throw new KernelNotCompiledException(nameof(LogKernel));
+		public Action<AcceleratorStream, Index1D, ArrayView<float>, ArrayView<float>, ArrayView<float>, int, SpecializedValue<int>> simdVectorKernel
+			= (_, _, _, _, _, _, _) => throw new KernelNotCompiledException(nameof(simdVectorKernel));
+
 		public void LoadKernels()
 		{
 			Stopwatch timer = new();
@@ -42,7 +61,7 @@ namespace BAVCL
 			appendKernel = accelerator.LoadAutoGroupedKernel<Index1D, ArrayView<float>, ArrayView<float>, ArrayView<float>, int, int>(AppendKernel);
 			nanToNumKernel = accelerator.LoadAutoGroupedKernel<Index1D, ArrayView<float>, float>(Nan_to_numKernel);
 			getSliceKernel = accelerator.LoadAutoGroupedKernel<Index1D, ArrayView<float>, ArrayView<float>, ArrayView<int>>(AccessSliceKernel);
-			
+
 			a_opFKernel = accelerator.LoadAutoGroupedKernel<Index1D, ArrayView<float>, ArrayView<float>, ArrayView<float>, SpecializedValue<int>>(A_FloatOPKernel);
 			s_opFKernel = accelerator.LoadAutoGroupedKernel<Index1D, ArrayView<float>, ArrayView<float>, float, SpecializedValue<int>>(S_FloatOPKernel);
 			vectormatrixOpKernel = accelerator.LoadAutoGroupedKernel<Index1D, ArrayView<float>, ArrayView<float>, ArrayView<float>, int, SpecializedValue<int>>(VectorMatrixKernel);
@@ -52,8 +71,8 @@ namespace BAVCL
 			a_FloatOPKernelIP = accelerator.LoadAutoGroupedKernel<Index1D, ArrayView<float>, ArrayView<float>, SpecializedValue<int>>(A_FloatOPKernelIP);
 			s_FloatOPKernelIP = accelerator.LoadAutoGroupedKernel<Index1D, ArrayView<float>, float, SpecializedValue<int>>(S_FloatOPKernelIP);
 
-			diffKernel = accelerator.LoadAutoGroupedKernel<Index1D, ArrayView<float>, ArrayView<float>> (DiffKernel);
-			reverseKernel = accelerator.LoadAutoGroupedKernel<Index1D, ArrayView<float>> (ReverseKernel);
+			diffKernel = accelerator.LoadAutoGroupedKernel<Index1D, ArrayView<float>, ArrayView<float>>(DiffKernel);
+			reverseKernel = accelerator.LoadAutoGroupedKernel<Index1D, ArrayView<float>>(ReverseKernel);
 			absKernel = accelerator.LoadAutoGroupedKernel<Index1D, ArrayView<float>>(AbsKernel);
 			rcpKernel = accelerator.LoadAutoGroupedKernel<Index1D, ArrayView<float>>(ReciprocalKernel);
 			rsqrtKernel = accelerator.LoadAutoGroupedKernel<Index1D, ArrayView<float>>(RsqrtKernel);
@@ -67,11 +86,11 @@ namespace BAVCL
 			timer.Stop();
 			Console.WriteLine($"Kernels Loaded in: {timer.Elapsed.TotalMilliseconds} MS");
 		}
-		
+
 		static void AppendKernel(Index1D index, ArrayView<float> Output, ArrayView<float> vecA, ArrayView<float> vecB, int vecAcol, int vecBcol)
 		{
 
-			for (int i = 0, j=0; j < vecBcol; i++)
+			for (int i = 0, j = 0; j < vecBcol; i++)
 			{
 				if (i < vecAcol)
 				{
@@ -297,7 +316,7 @@ namespace BAVCL
 		static void SIMDVectorKernel(Index1D index, ArrayView<float> Output, ArrayView<float> InputA, ArrayView<float> InputB, int Cols, SpecializedValue<int> operation)
 		{
 			int startidx = index * Cols;
-			
+
 			switch ((Operations)operation.Value)
 			{
 				case Operations.multiply:
@@ -317,7 +336,7 @@ namespace BAVCL
 					for (int i = 0; i < Cols; i++)
 						Output[index] += InputA[startidx + i] * InputB[startidx + i];
 					Output[index] = XMath.Sqrt(Output[index]);
-					break;				
+					break;
 			}
 		}
 
@@ -350,9 +369,9 @@ namespace BAVCL
 		static void CrossKernel(Index1D index, ArrayView<float> Output, ArrayView<float> InputA, ArrayView<float> InputB)
 		{
 			Index1D startIdx = index * 3;
-			Output[startIdx]     = InputA[startIdx + 1] * InputB[startIdx + 2] - InputA[startIdx + 2] * InputB[startIdx + 1];
-			Output[startIdx + 1] = InputA[startIdx + 2] * InputB[startIdx    ] - InputA[startIdx    ] * InputB[startIdx + 2];
-			Output[startIdx + 2] = InputA[startIdx    ] * InputB[startIdx + 1] - InputA[startIdx + 1] * InputB[startIdx    ];
+			Output[startIdx] = InputA[startIdx + 1] * InputB[startIdx + 2] - InputA[startIdx + 2] * InputB[startIdx + 1];
+			Output[startIdx + 1] = InputA[startIdx + 2] * InputB[startIdx] - InputA[startIdx] * InputB[startIdx + 2];
+			Output[startIdx + 2] = InputA[startIdx] * InputB[startIdx + 1] - InputA[startIdx + 1] * InputB[startIdx];
 		}
 
 		static void TransposeKernel(Index1D index, ArrayView<float> Output, ArrayView<float> Input, int columns)
@@ -368,8 +387,8 @@ namespace BAVCL
 
 		public static void LogKern(Index1D index, ArrayView<float> IO, float @base)
 		{
-			IO[index] = XMath.Log(IO[index],@base);
+			IO[index] = XMath.Log(IO[index], @base);
 		}
-		
+
 	}
 }

--- a/BAVCL/Core/GPU/Memory Management/Cache.cs
+++ b/BAVCL/Core/GPU/Memory Management/Cache.cs
@@ -3,17 +3,10 @@ using ILGPU.Runtime;
 using System;
 
 
-namespace BAVCL
-{
-    public struct Cache
-    {
-        public MemoryBuffer MemoryBuffer;
-        public WeakReference<ICacheable> CachedObjRef;
+namespace BAVCL;
 
-        public Cache(MemoryBuffer memoryBuffer, WeakReference<ICacheable> cachedObjRef)
-        {
-            MemoryBuffer = memoryBuffer;
-            CachedObjRef = cachedObjRef;
-        }
-    }
+public struct Cache(MemoryBuffer memoryBuffer, WeakReference<ICacheable> cachedObjRef)
+{
+    public MemoryBuffer MemoryBuffer = memoryBuffer;
+    public WeakReference<ICacheable> CachedObjRef = cachedObjRef;
 }

--- a/BAVCL/Core/GPU/Memory Management/LRU.cs
+++ b/BAVCL/Core/GPU/Memory Management/LRU.cs
@@ -61,7 +61,6 @@ namespace BAVCL.Core
             {
                 GC(memNeeded);
                 UpdateMemoryUsage(memNeeded);
-
                 buffer = accelerator.Allocate1D<T>(length);
                 Caches.TryAdd(id, new Cache(buffer, new WeakReference<ICacheable>(cacheable)));
                 _lru.Enqueue(id);

--- a/BAVCL/Core/Interfaces/IMemoryManager.cs
+++ b/BAVCL/Core/Interfaces/IMemoryManager.cs
@@ -5,6 +5,9 @@ namespace BAVCL.Core.Interfaces
 {
     public interface IMemoryManager
     {
+
+        public void LimitAccessibleMemory(long maxMemory, float memoryCap);
+
         #region Allocate
         public (uint, MemoryBuffer) Allocate<T>(ICacheable<T> Cacheable, Accelerator accelerator) where T : unmanaged;
         public (uint, MemoryBuffer) Allocate<T>(ICacheable Cacheable, T[] values, Accelerator accelerator) where T : unmanaged;
@@ -17,7 +20,7 @@ namespace BAVCL.Core.Interfaces
         #endregion
 
         #region Get
-        public MemoryBuffer GetBuffer(uint Id);
+        public MemoryBuffer? GetBuffer(uint Id);
         #endregion
 
         #region Garbage Collection
@@ -47,7 +50,7 @@ namespace BAVCL.Core.Interfaces
         /// The amount of memory available to be used accounting for headroom. 
         /// AvailableMemory <= MaxMemory.
         /// </summary>
-        public long AvailableMemory { get; init; }
+        public long AvailableMemory { get; }
         public long MemoryUsed { get; }
         protected internal long MemoryFree => AvailableMemory - MemoryUsed;
         #endregion

--- a/BAVCL/Core/Interfaces/IMemoryManager.cs
+++ b/BAVCL/Core/Interfaces/IMemoryManager.cs
@@ -6,11 +6,9 @@ namespace BAVCL.Core.Interfaces
     public interface IMemoryManager
     {
 
-        public void LimitAccessibleMemory(long maxMemory, float memoryCap);
-
         #region Allocate
-        public (uint, MemoryBuffer) Allocate<T>(ICacheable<T> Cacheable, Accelerator accelerator) where T : unmanaged;
-        public (uint, MemoryBuffer) Allocate<T>(ICacheable Cacheable, T[] values, Accelerator accelerator) where T : unmanaged;
+        public (uint, MemoryBuffer) Allocate<T>(ICacheable<T> cacheable, Accelerator accelerator) where T : unmanaged;
+        public (uint, MemoryBuffer) Allocate<T>(ICacheable cacheable, T[] values, Accelerator accelerator) where T : unmanaged;
         public (uint, MemoryBuffer) AllocateEmpty<T>(ICacheable cacheable, int length, Accelerator accelerator) where T : unmanaged;
         #endregion
 
@@ -50,7 +48,7 @@ namespace BAVCL.Core.Interfaces
         /// The amount of memory available to be used accounting for headroom. 
         /// AvailableMemory <= MaxMemory.
         /// </summary>
-        public long AvailableMemory { get; }
+        public long AvailableMemory { get; set; }
         public long MemoryUsed { get; }
         protected internal long MemoryFree => AvailableMemory - MemoryUsed;
         #endregion

--- a/BAVCL/Core/Vector/Abs.cs
+++ b/BAVCL/Core/Vector/Abs.cs
@@ -60,10 +60,10 @@ namespace BAVCL
             MemoryBuffer1D<float, Stride1D.Dense> buffer = GetBuffer(); // IO
 
             // RUN
-            gpu.absKernel(gpu.accelerator.DefaultStream, buffer.IntExtent, buffer.View);
+            Gpu.absKernel(Gpu.accelerator.DefaultStream, buffer.IntExtent, buffer.View);
 
             // SYNC
-            gpu.accelerator.Synchronize();
+            Gpu.accelerator.Synchronize();
 
             // Remove Security
             DecrementLiveCount();

--- a/BAVCL/Core/Vector/Append.cs
+++ b/BAVCL/Core/Vector/Append.cs
@@ -8,7 +8,7 @@ namespace BAVCL
         {
             vectorA.SyncCPU();
             vectorB.SyncCPU();
-            return new Vector(vectorA.gpu, vectorA.Value.Concat(vectorB.Value).ToArray(), vectorA.Columns);
+            return new Vector(vectorA.Gpu, vectorA.Value.Concat(vectorB.Value).ToArray(), vectorA.Columns);
         }
         public Vector Append_IP(Vector vector)
         {

--- a/BAVCL/Core/Vector/Concat.cs
+++ b/BAVCL/Core/Vector/Concat.cs
@@ -67,7 +67,7 @@ namespace BAVCL
 
             }
 
-            Vector Output = new(gpu, vector.Length + Length);
+            Vector Output = new(Gpu, vector.Length + Length);
 
             IncrementLiveCount();
             vector.IncrementLiveCount();
@@ -78,9 +78,9 @@ namespace BAVCL
                 buffer2 = GetBuffer(),              // Input
                 buffer3 = vector.GetBuffer();       // Input
 
-            gpu.appendKernel(gpu.accelerator.DefaultStream, this.RowCount(), buffer.View, buffer2.View, buffer3.View, this.Columns, vector.Columns);
+            Gpu.appendKernel(Gpu.accelerator.DefaultStream, this.RowCount(), buffer.View, buffer2.View, buffer3.View, this.Columns, vector.Columns);
 
-            gpu.accelerator.Synchronize();
+            Gpu.accelerator.Synchronize();
 
             DecrementLiveCount();
             vector.DecrementLiveCount();

--- a/BAVCL/Core/Vector/Diff.cs
+++ b/BAVCL/Core/Vector/Diff.cs
@@ -11,7 +11,7 @@ namespace BAVCL
             if (vector.Columns > 1)
                 throw new Exception("Diff is for use with 1D Vectors ONLY");
 
-            GPU gpu = vector.gpu;
+            GPU gpu = vector.Gpu;
 
             vector.IncrementLiveCount();
 

--- a/BAVCL/Core/Vector/GetColumn.cs
+++ b/BAVCL/Core/Vector/GetColumn.cs
@@ -15,8 +15,8 @@ namespace BAVCL
             vector.IncrementLiveCount();
 
             // Make Output Vector
-            Vector Output = new(vector.gpu, vector.RowCount());
-            
+            Vector Output = new(vector.Gpu, vector.RowCount());
+
             // Secure the Output
             Output.IncrementLiveCount();
 
@@ -27,13 +27,13 @@ namespace BAVCL
 
             // Allocate config Data onto GPU
             MemoryBuffer1D<int, Stride1D.Dense>
-                buffer3 = vector.gpu.accelerator.Allocate1D(select);      // Config
+                buffer3 = vector.Gpu.accelerator.Allocate1D(select);      // Config
 
             // RUN
-            vector.gpu.getSliceKernel(vector.gpu.accelerator.DefaultStream, vector.RowCount(), buffer.View, buffer2.View, buffer3.View);
+            vector.Gpu.getSliceKernel(vector.Gpu.accelerator.DefaultStream, vector.RowCount(), buffer.View, buffer2.View, buffer3.View);
 
             // SYNC
-            vector.gpu.accelerator.Synchronize();
+            vector.Gpu.accelerator.Synchronize();
 
             // Dispose of Config
             buffer3.Dispose();
@@ -54,7 +54,7 @@ namespace BAVCL
             IncrementLiveCount();
 
             // Make Output Vector
-            Vector Output = new(gpu, RowCount());
+            Vector Output = new(Gpu, RowCount());
 
             Output.IncrementLiveCount();
 
@@ -65,13 +65,13 @@ namespace BAVCL
 
             // Allocate config Data onto GPU
             MemoryBuffer1D<int, Stride1D.Dense>
-                buffer3 = gpu.accelerator.Allocate1D(select);     // Config
+                buffer3 = Gpu.accelerator.Allocate1D(select);     // Config
 
             // RUN
-            gpu.getSliceKernel(gpu.accelerator.DefaultStream, RowCount(), buffer.View, buffer2.View, buffer3.View);
+            Gpu.getSliceKernel(Gpu.accelerator.DefaultStream, RowCount(), buffer.View, buffer2.View, buffer3.View);
 
             // SYNC
-            gpu.accelerator.Synchronize();
+            Gpu.accelerator.Synchronize();
 
             // Dispose of Config
             buffer3.Dispose();

--- a/BAVCL/Core/Vector/GetRow.cs
+++ b/BAVCL/Core/Vector/GetRow.cs
@@ -25,14 +25,14 @@
         public static Vector GetRowAsVector(Vector vector, int row)
         {
             vector.SyncCPU();
-            return new Vector(vector.gpu, vector.Value[(row * vector.Columns)..(++row * vector.Columns)]);
+            return new Vector(vector.Gpu, vector.Value[(row * vector.Columns)..(++row * vector.Columns)]);
         }
 
 
         public Vector GetRowAsVector(int row)
         {
             SyncCPU();
-            return new Vector(gpu, Value[(row * Columns)..(++row * Columns)]);
+            return new Vector(Gpu, Value[(row * Columns)..(++row * Columns)]);
         }
 
 

--- a/BAVCL/Core/Vector/Merge.cs
+++ b/BAVCL/Core/Vector/Merge.cs
@@ -16,7 +16,7 @@ namespace BAVCL
         {
             vectorA.SyncCPU();
             vectorB.SyncCPU();
-            return new Vector(vectorA.gpu, vectorA.Value.Union(vectorB.Value).ToArray(), vectorA.Columns);
+            return new Vector(vectorA.Gpu, vectorA.Value.Union(vectorB.Value).ToArray(), vectorA.Columns);
         }
         /// <summary>
         /// Concatinates Vector onto the end of this Vector removing any duplicates.

--- a/BAVCL/Core/Vector/NanToNum.cs
+++ b/BAVCL/Core/Vector/NanToNum.cs
@@ -15,9 +15,9 @@ namespace BAVCL
 
             MemoryBuffer1D<float, Stride1D.Dense> buffer = GetBuffer();
 
-            gpu.nanToNumKernel(gpu.accelerator.DefaultStream, Length, buffer.View, num);
+            Gpu.nanToNumKernel(Gpu.accelerator.DefaultStream, Length, buffer.View, num);
 
-            gpu.accelerator.Synchronize();
+            Gpu.accelerator.Synchronize();
 
             DecrementLiveCount();
 

--- a/BAVCL/Core/Vector/Reciprocal.cs
+++ b/BAVCL/Core/Vector/Reciprocal.cs
@@ -15,9 +15,9 @@ namespace BAVCL
             // Check if the input & output are in Cache
             MemoryBuffer1D<float, Stride1D.Dense> buffer = GetBuffer(); // IO
 
-            gpu.rcpKernel(gpu.accelerator.DefaultStream, buffer.IntExtent, buffer.View);
+            Gpu.rcpKernel(Gpu.accelerator.DefaultStream, buffer.IntExtent, buffer.View);
 
-            gpu.accelerator.Synchronize();
+            Gpu.accelerator.Synchronize();
 
             DecrementLiveCount();
 

--- a/BAVCL/Core/Vector/Reverse.cs
+++ b/BAVCL/Core/Vector/Reverse.cs
@@ -6,8 +6,8 @@ namespace BAVCL
 {
     public partial class Vector
     {
-        public static Vector Reverse(Vector vector) => 
-            new(vector.gpu, vector.Value.Reverse().ToArray(), vector.Columns);
+        public static Vector Reverse(Vector vector) =>
+            new(vector.Gpu, vector.Value.Reverse().ToArray(), vector.Columns);
 
         public Vector Reverse_IP()
         {
@@ -15,7 +15,7 @@ namespace BAVCL
             UpdateCache(Value.Reverse().ToArray());
             return this;
         }
-        public static Vector ReverseX(Vector vector) => 
+        public static Vector ReverseX(Vector vector) =>
             vector.Copy().ReverseX_IP();
 
         public Vector ReverseX_IP()
@@ -25,9 +25,9 @@ namespace BAVCL
             // Check if the input & output are in Cache
             MemoryBuffer1D<float, Stride1D.Dense> buffer = GetBuffer(); // IO
 
-            gpu.reverseKernel(gpu.accelerator.DefaultStream, buffer.IntExtent >> 1, buffer.View);
+            Gpu.reverseKernel(Gpu.accelerator.DefaultStream, buffer.IntExtent >> 1, buffer.View);
 
-            gpu.accelerator.Synchronize();
+            Gpu.accelerator.Synchronize();
 
             DecrementLiveCount();
 

--- a/BAVCL/Core/Vector/Rsqrt.cs
+++ b/BAVCL/Core/Vector/Rsqrt.cs
@@ -14,7 +14,7 @@ namespace BAVCL
         /// <param name="vector"></param>
         /// <returns></returns>
         public static Vector Rsqrt(Vector vector) => vector.Copy().Rsqrt_IP();
-        
+
         /// <summary>
         /// Takes the absolute value of all values in this Vector.
         /// IMPORTANT : Use this method for Vectors of Length less than 100,000
@@ -58,10 +58,10 @@ namespace BAVCL
             MemoryBuffer1D<float, Stride1D.Dense> buffer = GetBuffer(); // IO
 
             // RUN
-            gpu.rsqrtKernel(gpu.accelerator.DefaultStream, buffer.IntExtent, buffer.View);
+            Gpu.rsqrtKernel(Gpu.accelerator.DefaultStream, buffer.IntExtent, buffer.View);
 
             // SYNC
-            gpu.accelerator.Synchronize();
+            Gpu.accelerator.Synchronize();
 
             // Remove Security
             DecrementLiveCount();

--- a/BAVCL/Core/Vector/ToString.cs
+++ b/BAVCL/Core/Vector/ToString.cs
@@ -9,12 +9,16 @@ namespace BAVCL
     {
         public override string ToString()
         {
-            return ToStr(2,false);
+            return ToStr(2, false);
         }
 
         public string ToStr(byte decimalplaces = 2, bool syncCPU = true)
         {
-            if ((Value == null) || syncCPU) { SyncCPU(); }
+            if ((Value == null) || syncCPU)
+                SyncCPU();
+
+            if (Value == null)
+                throw new Exception("Vector has no data to convert to string\n Func - ToString - Vector");
 
             (float min, float max, bool hasinfinity) = Util.MinMaxInf(Value);
 
@@ -23,7 +27,7 @@ namespace BAVCL
             int high = max.ToString().Length;
             int low = hasnegative ? min.ToString().Length - 1 : min.ToString().Length;
 
-            int digits = high > low ? high: low;
+            int digits = high > low ? high : low;
 
             string format = $"F{decimalplaces}";
 
@@ -43,7 +47,7 @@ namespace BAVCL
 
             if (hasinfinity)
             {
-                string 
+                string
                     inf = new(' ', digits - 3),
                     afterinf = new(' ', decimalplaces + 1),
                     nan = new(' ', decimalplaces);

--- a/BAVCL/Core/Vector/ToString.cs
+++ b/BAVCL/Core/Vector/ToString.cs
@@ -17,10 +17,7 @@ namespace BAVCL
             if ((Value == null) || syncCPU)
                 SyncCPU();
 
-            if (Value == null)
-                throw new Exception("Vector has no data to convert to string\n Func - ToString - Vector");
-
-            (float min, float max, bool hasinfinity) = Util.MinMaxInf(Value);
+            (float min, float max, bool hasinfinity) = Util.MinMaxInf(Value!);
 
             bool hasnegative = min < 0f;
 
@@ -57,12 +54,12 @@ namespace BAVCL
                 {
                     if (i % Columns == 0) { stringBuilder.AppendLine(); }
 
-                    Template[2] = Value[i] < 0f ? '-' : ' ';
+                    Template[2] = Value![i] < 0f ? '-' : ' ';
 
-                    if (float.IsFinite(Value[i]))
+                    if (float.IsFinite(Value![i]))
                     {
                         clear.CopyTo(Template, 3);
-                        string val = Math.Abs(Value[i]).ToString(format);
+                        string val = Math.Abs(Value![i]).ToString(format);
                         val.CopyTo(0, Template, _diff - val.Length, val.Length);
 
                         stringBuilder.Append(Template);
@@ -97,10 +94,10 @@ namespace BAVCL
                 {
                     if (i % Columns == 0) { stringBuilder.AppendLine(); }
 
-                    Template[2] = Value[i] < 0f ? '-' : ' ';
+                    Template[2] = Value![i] < 0f ? '-' : ' ';
 
                     clear.CopyTo(Template, 3);
-                    string val = Math.Abs(Value[i]).ToString(format);
+                    string val = Math.Abs(Value![i]).ToString(format);
                     val.CopyTo(0, Template, _diff - val.Length, val.Length);
 
                     stringBuilder.Append(Template);
@@ -116,7 +113,7 @@ namespace BAVCL
                 if (i % Columns == 0) { stringBuilder.AppendLine(); }
 
                 clear.CopyTo(Template, 3);
-                string val = Value[i].ToString(format);
+                string val = Value![i].ToString(format);
                 val.CopyTo(0, Template, _diff - val.Length, val.Length);
 
                 stringBuilder.Append(Template);

--- a/BAVCL/Core/Vector/TransferBuffer.cs
+++ b/BAVCL/Core/Vector/TransferBuffer.cs
@@ -4,7 +4,7 @@
     {
         public static Vector TransferBuffer(Vector Inheritee, Vector Temp, bool IncColumns = false)
         {
-            Inheritee.gpu.GCItem(Inheritee.ID);
+            Inheritee.Gpu.GCItem(Inheritee.ID);
             Inheritee.ID = Temp.ID;
             Inheritee.Value = Temp.Value;
             if (IncColumns) { Inheritee.Columns = Temp.Columns; }
@@ -13,9 +13,9 @@
             return Inheritee;
         }
 
-        public Vector TransferBuffer(Vector Temp, bool IncColumns=false)
+        public Vector TransferBuffer(Vector Temp, bool IncColumns = false)
         {
-            gpu.GCItem(ID);
+            Gpu.GCItem(ID);
             ID = Temp.ID;
             Value = Temp.Value;
             if (IncColumns) { Columns = Temp.Columns; }

--- a/BAVCL/Core/Vector/Transpose.cs
+++ b/BAVCL/Core/Vector/Transpose.cs
@@ -14,7 +14,7 @@ namespace BAVCL
             vector.IncrementLiveCount();
 
             // Make the Output Vector
-            Vector Output = new(vector.gpu, vector.Length, vector.RowCount());
+            Vector Output = new(vector.Gpu, vector.Length, vector.RowCount());
 
             // Prevent from decache
             Output.IncrementLiveCount();
@@ -23,9 +23,9 @@ namespace BAVCL
                 buffer = Output.GetBuffer(), // Output
                 buffer2 = vector.GetBuffer(); // Input
 
-            vector.gpu.transposekernel(vector.gpu.accelerator.DefaultStream, buffer.IntExtent, buffer.View, buffer2.View, vector.Columns);
+            vector.Gpu.transposekernel(vector.Gpu.accelerator.DefaultStream, buffer.IntExtent, buffer.View, buffer2.View, vector.Columns);
 
-            vector.gpu.accelerator.Synchronize();
+            vector.Gpu.accelerator.Synchronize();
 
             vector.DecrementLiveCount();
             Output.DecrementLiveCount();

--- a/BAVCL/Core/Vector/Vector.cs
+++ b/BAVCL/Core/Vector/Vector.cs
@@ -27,8 +27,9 @@ namespace BAVCL
 		{ }
 
 		/// <summary>
-		/// Constructs a Vector object of length 'length' with all values set to default or 0.
-		/// Should be more efficient for creating output vectors, and zero/default initiased vectors.
+		/// Constructs a Vector object of length 'length' with uninitialized values.
+		/// Ideal for creating output vectors. JUST REMEMBER TO SET/UPDATE ALL VALUES.
+		/// WARNING: Values are NOT initialized to zero, and you may get random leftover data.
 		/// </summary>
 		/// <param name="gpu"></param>
 		/// <param name="length"></param>

--- a/BAVCL/Core/Vector/Vector.cs
+++ b/BAVCL/Core/Vector/Vector.cs
@@ -59,9 +59,9 @@ namespace BAVCL
 		public Vector Copy(bool Cache = true)
 		{
 			if (ID == 0)
-				return new Vector(gpu, Value[..], Columns, Cache);
+				return new Vector(Gpu, Value[..], Columns, Cache);
 
-			return new Vector(gpu, Pull(), Columns, Cache);
+			return new Vector(Gpu, Pull(), Columns, Cache);
 		}
 
 		#region "MATHEMATICAL PROPERTIES"
@@ -135,9 +135,9 @@ namespace BAVCL
 		{
 			if (Length % 3 != 0) { throw new Exception("Vector length must be a multiple of 3"); }
 			if (ID != 0)
-				return new Geometric.Vector3(gpu, Pull());
+				return new Geometric.Vector3(Gpu, Pull());
 
-			return new Geometric.Vector3(gpu, Value);
+			return new Geometric.Vector3(Gpu, Value);
 		}
 
 		#endregion
@@ -232,7 +232,7 @@ namespace BAVCL
 
 		public static Vector OP(Vector vector, float scalar, Operations operation)
 		{
-			GPU gpu = vector.gpu;
+			GPU gpu = vector.Gpu;
 
 			vector.IncrementLiveCount();
 
@@ -263,9 +263,9 @@ namespace BAVCL
 			// Check if the input & output are in Cache
 			MemoryBuffer1D<float, Stride1D.Dense> buffer = GetBuffer(); // IO
 
-			gpu.s_FloatOPKernelIP(gpu.accelerator.DefaultStream, buffer.IntExtent, buffer.View, scalar, new SpecializedValue<int>((int)operation));
+			Gpu.s_FloatOPKernelIP(Gpu.accelerator.DefaultStream, buffer.IntExtent, buffer.View, scalar, new SpecializedValue<int>((int)operation));
 
-			gpu.accelerator.Synchronize();
+			Gpu.accelerator.Synchronize();
 
 			DecrementLiveCount();
 
@@ -275,7 +275,7 @@ namespace BAVCL
 
 		internal static Vector _VectorVectorOP(Vector vectorA, Vector vectorB, Operations operation)
 		{
-			GPU gpu = vectorA.gpu;
+			GPU gpu = vectorA.Gpu;
 
 			vectorA.IncrementLiveCount();
 			vectorB.IncrementLiveCount();
@@ -315,10 +315,10 @@ namespace BAVCL
 				buffer2 = vectorB.GetBuffer();      // Input
 
 			// Run the kernel
-			gpu.a_FloatOPKernelIP(gpu.accelerator.DefaultStream, buffer.IntExtent, buffer.View, buffer2.View, new SpecializedValue<int>((int)operation));
+			Gpu.a_FloatOPKernelIP(Gpu.accelerator.DefaultStream, buffer.IntExtent, buffer.View, buffer2.View, new SpecializedValue<int>((int)operation));
 
 			// Synchronise the kernel
-			gpu.accelerator.Synchronize();
+			Gpu.accelerator.Synchronize();
 
 			vectorB.DecrementLiveCount();
 			DecrementLiveCount();
@@ -328,7 +328,7 @@ namespace BAVCL
 
 		internal static Vector _VectorMatrixOP(Vector vector, Vector matrix, Operations operation)
 		{
-			GPU gpu = vector.gpu;
+			GPU gpu = vector.Gpu;
 
 			vector.IncrementLiveCount();
 			matrix.IncrementLiveCount();
@@ -365,7 +365,7 @@ namespace BAVCL
 			matrix.IncrementLiveCount();
 
 			// Make the Output Vector
-			Vector Output = new(gpu, matrix.Length, Columns);
+			Vector Output = new(Gpu, matrix.Length, Columns);
 
 			Output.IncrementLiveCount();
 
@@ -376,10 +376,10 @@ namespace BAVCL
 				buffer3 = matrix.GetBuffer();       // Input
 
 			// Run the kernel
-			gpu.vectormatrixOpKernel(gpu.accelerator.DefaultStream, matrix.RowCount(), buffer.View, buffer2.View, buffer3.View, matrix.Columns, new SpecializedValue<int>((int)operation));
+			Gpu.vectormatrixOpKernel(Gpu.accelerator.DefaultStream, matrix.RowCount(), buffer.View, buffer2.View, buffer3.View, matrix.Columns, new SpecializedValue<int>((int)operation));
 
 			// Synchronise the kernel
-			gpu.accelerator.Synchronize();
+			Gpu.accelerator.Synchronize();
 
 			DecrementLiveCount();
 			matrix.DecrementLiveCount();
@@ -396,9 +396,9 @@ namespace BAVCL
 
 			MemoryBuffer1D<float, Stride1D.Dense> buffer = GetBuffer();
 
-			gpu.LogKernel(gpu.accelerator.DefaultStream, buffer.IntExtent, buffer.View, @base);
+			Gpu.LogKernel(Gpu.accelerator.DefaultStream, buffer.IntExtent, buffer.View, @base);
 
-			gpu.accelerator.Synchronize();
+			Gpu.accelerator.Synchronize();
 
 			DecrementLiveCount();
 

--- a/BAVCL/Core/Vector/Zeros.cs
+++ b/BAVCL/Core/Vector/Zeros.cs
@@ -2,7 +2,8 @@
 {
     public partial class Vector
     {
-        public static Vector Zeros(GPU gpu, int Length, int Columns = 1) => new(gpu, Length, Columns);
+        public static Vector Zeros(GPU gpu, int Length, int Columns = 1)
+            => new(gpu, new float[Length], Columns);
 
         public Vector Zeros_IP(int Length, int Columns = 1)
         {

--- a/BAVCL/Core/VectorBase/Allocate.cs
+++ b/BAVCL/Core/VectorBase/Allocate.cs
@@ -7,10 +7,10 @@ namespace BAVCL.Core
     {
 
         public MemoryBuffer1D<T, Stride1D.Dense> Allocate() =>
-            this.gpu.accelerator.Allocate1D(this.Value);
+            this.Gpu.accelerator.Allocate1D(this.Value);
 
-        public MemoryBuffer1D<T,Stride1D.Dense> Allocate(T[] array) =>
-            this.gpu.accelerator.Allocate1D(array);
+        public MemoryBuffer1D<T, Stride1D.Dense> Allocate(T[] array) =>
+            this.Gpu.accelerator.Allocate1D(array);
 
     }
 

--- a/BAVCL/Core/VectorBase/Cache.cs
+++ b/BAVCL/Core/VectorBase/Cache.cs
@@ -8,25 +8,25 @@ namespace BAVCL.Core
 		/// Store info about data to LRU
 		/// </summary>
 		internal MemoryBuffer Cache()
-        {
-			(ID, MemoryBuffer buffer) = gpu.Allocate(this);
+		{
+			(ID, MemoryBuffer buffer) = Gpu.Allocate(this);
 			return buffer;
 		}
-			
+
 
 		/// <summary>
 		/// Store info about data to LRU
 		/// </summary>
 		internal MemoryBuffer Cache(T[] array)
-        {
-			(ID, MemoryBuffer buffer) = gpu.Allocate(this,array);
+		{
+			(ID, MemoryBuffer buffer) = Gpu.Allocate(this, array);
 			return buffer;
 		}
 
 
 		internal MemoryBuffer CacheEmpty(int length)
-        {
-			(ID, MemoryBuffer buffer) = gpu.AllocateEmpty<T>(this, length);
+		{
+			(ID, MemoryBuffer buffer) = Gpu.AllocateEmpty<T>(this, length);
 			return buffer;
 		}
 

--- a/BAVCL/Core/VectorBase/GetBuffer.cs
+++ b/BAVCL/Core/VectorBase/GetBuffer.cs
@@ -1,19 +1,15 @@
 ﻿using ILGPU;
 using ILGPU.Runtime;
 
-namespace BAVCL.Core
+namespace BAVCL.Core;
+
+public partial class VectorBase<T>
 {
-    public partial class VectorBase<T>
-    {
-        /// <summary>
-        /// NOTE: This does NOT update the Length property
-        /// </summary>
-        /// <returns></returns>
-        public MemoryBuffer1D<T, Stride1D.Dense> GetBuffer() =>
-            (MemoryBuffer1D<T, Stride1D.Dense>)(gpu.TryGetBuffer<T>(ID) ?? Cache()); 
+    /// <summary>
+    /// NOTE: This does NOT update the Length property
+    /// </summary>
+    /// <returns></returns>
+    public MemoryBuffer1D<T, Stride1D.Dense> GetBuffer() =>
+        (MemoryBuffer1D<T, Stride1D.Dense>)(Gpu.TryGetBuffer<T>(ID) ?? Cache());
 
-
-    }
-
-     
 }

--- a/BAVCL/Core/VectorBase/TryDeCache.cs
+++ b/BAVCL/Core/VectorBase/TryDeCache.cs
@@ -12,7 +12,7 @@
 
             // Else Decache
             Value = Pull();
-            ID = gpu.GCItem(ID);
+            ID = Gpu.GCItem(ID);
         }
 
 

--- a/BAVCL/Core/VectorBase/UpdateCache.cs
+++ b/BAVCL/Core/VectorBase/UpdateCache.cs
@@ -9,14 +9,14 @@ namespace BAVCL.Core
             Length = Value.Length;
             if (ID == 0) return Cache();
 
-            ID = gpu.GCItem(ID);
+            ID = Gpu.GCItem(ID);
             return Cache();
         }
 
         public MemoryBuffer UpdateCache(T[] array)
         {
             Length = array.Length;
-            (ID, MemoryBuffer buffer) = gpu.UpdateBuffer(this, array);
+            (ID, MemoryBuffer buffer) = Gpu.UpdateBuffer(this, array);
             return buffer;
         }
 

--- a/BAVCL/Core/VectorBase/VectorBase.cs
+++ b/BAVCL/Core/VectorBase/VectorBase.cs
@@ -7,9 +7,9 @@ namespace BAVCL.Core
 {
 	public abstract partial class VectorBase<T> : ICacheable<T>, IIO where T : unmanaged
 	{
-		protected GPU gpu;
+		protected GPU Gpu;
 
-		public T[] Value = Array.Empty<T>();
+		public T[] Value = [];
 
 		public virtual int Columns
 		{
@@ -53,7 +53,7 @@ namespace BAVCL.Core
 		/// <summary>
 		protected VectorBase(GPU gpu, T[] value, int columns = 1, bool Cache = true)
 		{
-			this.gpu = gpu;
+			Gpu = gpu;
 			Columns = columns;
 			Value = value;
 			Length = value.Length;
@@ -63,9 +63,9 @@ namespace BAVCL.Core
 
 		protected VectorBase(GPU gpu, int length, int columns = 1)
 		{
-			this.gpu = gpu;
+			this.Gpu = gpu;
 			Columns = columns;
-			Value = null;
+			Value = [];
 			Length = length;
 			CacheEmpty(length);
 		}

--- a/BAVCL/Core/VectorBase/VectorBase.cs
+++ b/BAVCL/Core/VectorBase/VectorBase.cs
@@ -61,9 +61,17 @@ namespace BAVCL.Core
 			if (Cache) this.Cache(value);
 		}
 
+		/// <summary>
+		/// Creates an 'empty' vector of specified length.
+		/// Warning: May contain random leftover data. 
+		///	Initialize values before use OR use `Zeros` method.  
+		/// </summary>
+		/// <param name="gpu"></param>
+		/// <param name="length"></param>
+		/// <param name="columns"></param>
 		protected VectorBase(GPU gpu, int length, int columns = 1)
 		{
-			this.Gpu = gpu;
+			Gpu = gpu;
 			Columns = columns;
 			Value = [];
 			Length = length;
@@ -98,8 +106,8 @@ namespace BAVCL.Core
 		public abstract T Mean();
 		public abstract T Range();
 		public abstract T Sum();
-		public bool IsRectangular() => this.Length % this.Columns == 0;
-		public bool Is1D() => this.Columns == 1;
+		public bool IsRectangular() => Length % Columns == 0;
+		public bool Is1D() => Columns == 1;
 
 	}
 

--- a/BAVCL/Geometric/Vector3/AccessRow.cs
+++ b/BAVCL/Geometric/Vector3/AccessRow.cs
@@ -7,6 +7,6 @@ public sealed partial class Vector3 : VectorBase<float>
     public static Vector3 AccessRow(Vector3 vector, int vert_row)
     {
         vector.SyncCPU();
-        return new Vector3(vector.gpu, vector.Value[(vert_row * 3)..((vert_row + 1) * 3)]);
+        return new Vector3(vector.Gpu, vector.Value[(vert_row * 3)..((vert_row + 1) * 3)]);
     }
 }

--- a/BAVCL/Geometric/Vector3/Copy.cs
+++ b/BAVCL/Geometric/Vector3/Copy.cs
@@ -8,8 +8,8 @@ public sealed partial class Vector3 : VectorBase<float>
     {
         if (_id != 0)
         {
-            return new Vector3(gpu, Pull());
+            return new Vector3(Gpu, Pull());
         }
-        return new Vector3(gpu, Value[..]);
+        return new Vector3(Gpu, Value[..]);
     }
 }

--- a/BAVCL/Geometric/Vector3/CrossProduct.cs
+++ b/BAVCL/Geometric/Vector3/CrossProduct.cs
@@ -10,7 +10,7 @@ namespace BAVCL.Geometric
         {
             if (VectorA.Length != VectorB.Length) { throw new Exception($"Cannot Cross Product two Vector3's together of different lengths. {VectorA.Length} != {VectorB.Length}"); }
 
-            GPU gpu = VectorA.gpu;
+            GPU gpu = VectorA.Gpu;
 
             Vector3 Output = new(gpu, VectorA.Length);
 
@@ -34,7 +34,7 @@ namespace BAVCL.Geometric
             return Output;
 
         }
-    
-    
+
+
     }
 }

--- a/BAVCL/Geometric/Vector3/Operations.cs
+++ b/BAVCL/Geometric/Vector3/Operations.cs
@@ -23,7 +23,7 @@ namespace BAVCL.Geometric
 				buffer = output.GetBuffer(),        // Output
 				buffer2 = vector.GetBuffer();      // Input
 
-			gpu.simdVectorKernel(gpu._defaultStream, buffer.IntExtent, buffer.View, buffer2.View, buffer2.View, 3, new SpecializedValue<int>((int)operation));
+			gpu.simdVectorKernel(gpu.DefaultStream, buffer.IntExtent, buffer.View, buffer2.View, buffer2.View, 3, new SpecializedValue<int>((int)operation));
 			gpu.Synchronize();
 
 			vector.DecrementLiveCount();
@@ -48,7 +48,7 @@ namespace BAVCL.Geometric
 				buffer2 = vectorA.GetBuffer(),      // Input
 				buffer3 = vectorB.GetBuffer();      // Input
 
-			gpu.simdVectorKernel(gpu._defaultStream, buffer.IntExtent, buffer.View, buffer2.View, buffer3.View, 3, new SpecializedValue<int>((int)operation));
+			gpu.simdVectorKernel(gpu.DefaultStream, buffer.IntExtent, buffer.View, buffer2.View, buffer3.View, 3, new SpecializedValue<int>((int)operation));
 			gpu.Synchronize();
 
 			vectorA.DecrementLiveCount();

--- a/BAVCL/Geometric/Vector3/Operations.cs
+++ b/BAVCL/Geometric/Vector3/Operations.cs
@@ -8,33 +8,33 @@ namespace BAVCL.Geometric
 
 	public partial class Vector3
 	{
-		
+
 		public static Vector VOP(Vector3 vector, Operations operation)
 		{
-			GPU gpu = vector.gpu;
+			GPU gpu = vector.Gpu;
 
 			vector.IncrementLiveCount();
 
 			// Make the Output Vector
 			Vector output = Vector.Zeros(gpu, vector.RowCount());
 			output.IncrementLiveCount();
-			
+
 			MemoryBuffer1D<float, Stride1D.Dense>
 				buffer = output.GetBuffer(),        // Output
 				buffer2 = vector.GetBuffer();      // Input
-				
-			gpu.simdVectorKernel(gpu.DefaultStream, buffer.IntExtent, buffer.View, buffer2.View, buffer2.View, 3, new SpecializedValue<int>((int)operation));
+
+			gpu.simdVectorKernel(gpu._defaultStream, buffer.IntExtent, buffer.View, buffer2.View, buffer2.View, 3, new SpecializedValue<int>((int)operation));
 			gpu.Synchronize();
-			
+
 			vector.DecrementLiveCount();
 			output.DecrementLiveCount();
-			
+
 			return output;
 		}
-		
+
 		public static Vector VOP(Vector3 vectorA, Vector3 vectorB, Operations operation)
 		{
-			GPU gpu = vectorA.gpu;
+			GPU gpu = vectorA.Gpu;
 
 			vectorA.IncrementLiveCount();
 			vectorB.IncrementLiveCount();
@@ -42,25 +42,25 @@ namespace BAVCL.Geometric
 			// Make the Output Vector
 			Vector output = Vector.Zeros(gpu, vectorA.RowCount());
 			output.IncrementLiveCount();
-			
+
 			MemoryBuffer1D<float, Stride1D.Dense>
 				buffer = output.GetBuffer(),        // Output
 				buffer2 = vectorA.GetBuffer(),      // Input
 				buffer3 = vectorB.GetBuffer();      // Input
-				
-			gpu.simdVectorKernel(gpu.DefaultStream, buffer.IntExtent, buffer.View, buffer2.View, buffer3.View, 3, new SpecializedValue<int>((int)operation));
+
+			gpu.simdVectorKernel(gpu._defaultStream, buffer.IntExtent, buffer.View, buffer2.View, buffer3.View, 3, new SpecializedValue<int>((int)operation));
 			gpu.Synchronize();
-			
+
 			vectorA.DecrementLiveCount();
 			vectorB.DecrementLiveCount();
 			output.DecrementLiveCount();
-			
+
 			return output;
 		}
 
 		public static Vector3 OP(Vector3 vectorA, Vector3 vectorB, Operations operation)
 		{
-			GPU gpu = vectorA.gpu;
+			GPU gpu = vectorA.Gpu;
 
 			vectorA.IncrementLiveCount();
 			vectorB.IncrementLiveCount();
@@ -90,7 +90,7 @@ namespace BAVCL.Geometric
 		}
 		public Vector3 OP(Vector3 vector, Operations operation)
 		{
-			GPU gpu = this.gpu;
+			GPU gpu = this.Gpu;
 
 			IncrementLiveCount();
 			vector.IncrementLiveCount();
@@ -122,7 +122,7 @@ namespace BAVCL.Geometric
 
 		public static Vector3 OP(Vector3 vector, float scalar, Operations operation)
 		{
-			GPU gpu = vector.gpu;
+			GPU gpu = vector.Gpu;
 
 			vector.IncrementLiveCount();
 
@@ -147,7 +147,7 @@ namespace BAVCL.Geometric
 		}
 		public Vector3 OP(float scalar, Operations operation)
 		{
-			GPU gpu = this.gpu;
+			GPU gpu = this.Gpu;
 
 			IncrementLiveCount();
 
@@ -174,20 +174,20 @@ namespace BAVCL.Geometric
 
 		public Vector3 OP_IP(Vector3 vector, Operations operation)
 		{
-			
+
 			IncrementLiveCount();
 			vector.IncrementLiveCount();
-			
+
 			// Check if the input & output are in Cache
 			MemoryBuffer1D<float, Stride1D.Dense>
 				buffer = GetBuffer(),               // IO
 				buffer2 = vector.GetBuffer();       // Input
 
 			// Run the kernel
-			gpu.a_FloatOPKernelIP(gpu.accelerator.DefaultStream, buffer.IntExtent, buffer.View, buffer2.View, new SpecializedValue<int>((int)operation));
+			Gpu.a_FloatOPKernelIP(Gpu.accelerator.DefaultStream, buffer.IntExtent, buffer.View, buffer2.View, new SpecializedValue<int>((int)operation));
 
 			// Synchronise the kernel
-			gpu.accelerator.Synchronize();
+			Gpu.accelerator.Synchronize();
 
 			vector.DecrementLiveCount();
 			DecrementLiveCount();
@@ -201,9 +201,9 @@ namespace BAVCL.Geometric
 			// Check if the input & output are in Cache
 			MemoryBuffer1D<float, Stride1D.Dense> buffer = GetBuffer(); // IO
 
-			gpu.s_FloatOPKernelIP(gpu.accelerator.DefaultStream, buffer.IntExtent, buffer.View, scalar, new SpecializedValue<int>((int)operation));
+			Gpu.s_FloatOPKernelIP(Gpu.accelerator.DefaultStream, buffer.IntExtent, buffer.View, scalar, new SpecializedValue<int>((int)operation));
 
-			gpu.accelerator.Synchronize();
+			Gpu.accelerator.Synchronize();
 
 			DecrementLiveCount();
 

--- a/BAVCL/Geometric/Vector3/Vector3.cs
+++ b/BAVCL/Geometric/Vector3/Vector3.cs
@@ -12,9 +12,9 @@ namespace BAVCL.Geometric
 		#endregion
 
 		// CONSTRUCTOR
-		public Vector3(GPU gpu, float[] value, bool cache = true) : base(gpu, ValidateVectorLength(value), 3, cache) {}
+		public Vector3(GPU gpu, float[] value, bool cache = true) : base(gpu, ValidateVectorLength(value), 3, cache) { }
 
-		public Vector3(GPU gpu, int length) : base(gpu, ValidateVectorLength(length), 3) {}
+		public Vector3(GPU gpu, int length) : base(gpu, ValidateVectorLength(length), 3) { }
 
 		private static float[] ValidateVectorLength(float[] values)
 		{
@@ -31,22 +31,22 @@ namespace BAVCL.Geometric
 		/*
 		* TODO: Conversion between the vector types can be optimised by simply passing the 
 		* Memory buffer reference to the new vector, i.e. the ID if not 0
-		*/ 
+		*/
 		public Vector ToVector(bool cache = true)
 		{
 			if (_id != 0)
 			{
-				return new Vector(this.gpu, Pull(), this.Columns, cache);
+				return new Vector(this.Gpu, Pull(), this.Columns, cache);
 			}
-			return new Vector(this.gpu, this.Value, this.Columns, cache);
+			return new Vector(this.Gpu, this.Value, this.Columns, cache);
 		}
 		public Vector ToVector(int Columns, bool cache = true)
 		{
 			if (_id != 0)
 			{
-				return new Vector(this.gpu, Pull(), this.Columns, cache);
+				return new Vector(this.Gpu, Pull(), this.Columns, cache);
 			}
-			return new Vector(this.gpu, this.Value, Columns, cache);
+			return new Vector(this.Gpu, this.Value, Columns, cache);
 		}
 
 

--- a/BAVCL/IO/IO.cs
+++ b/BAVCL/IO/IO.cs
@@ -11,10 +11,10 @@ namespace BAVCL.IO
         // WRITE TO FILE
 
         // GENERIC
-        public static void WriteToFile(string input, string filename="new file", string format="txt" ,string path = "")
+        public static void WriteToFile(string input, string filename = "new file", string format = "txt", string path = "")
         {
             if (path == "") { path = AppDomain.CurrentDomain.BaseDirectory; }
-            Directory.CreateDirectory(path+@"\saved_data\");
+            Directory.CreateDirectory(path + @"\saved_data\");
             string fullpath = $"{path}/saved_data/{filename}.{format}";
 
             using (StreamWriter writer = new(fullpath))
@@ -43,7 +43,7 @@ namespace BAVCL.IO
         {
             return format switch
             {
-                "txt" => writable.ToString(),
+                "txt" => writable.ToString()!,
                 "csv" => writable.ToCSV(),
                 _ => throw new Exception($"No format : {format} available\n Func - ConvertToFormat - IO"),
             };
@@ -52,15 +52,15 @@ namespace BAVCL.IO
 
         // READ FROM FILE
 
-        public static Vector CSV2Vector(GPU gpu, string filename, string format="csv", string path="")
+        public static Vector CSV2Vector(GPU gpu, string filename, string format = "csv", string path = "")
         {
             if (path == "") { path = AppDomain.CurrentDomain.BaseDirectory; }
-            
+
             string contents = File.ReadAllText($"{path}/saved_data/{filename}.{format}");
 
             // CSV
 
-            int columns = Regex.Match(contents, @"^.*?(?=\n)").ToString().Split(",").Length-1;
+            int columns = Regex.Match(contents, @"^.*?(?=\n)").ToString().Split(",").Length - 1;
 
             float[] Output = Array.ConvertAll(contents.Replace("\r\n", "").Split(",").ToArray()[..^1], float.Parse);
 

--- a/BAVCL/Plotting/Plotter.cs
+++ b/BAVCL/Plotting/Plotter.cs
@@ -1,9 +1,8 @@
-﻿using BAVCL.Geometric;
+﻿using BAVCL.Services;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
-using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 
@@ -14,12 +13,12 @@ namespace BAVCL.Plotting
     {
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "<Pending>")]
-        public static void Noise(int width= 800, int height=600)
+        public static void Noise(int width = 800, int height = 600)
         {
             Bitmap b = new(width, height, PixelFormat.Format24bppRgb);
 
             Rectangle BoundsRect = new(0, 0, width, height);
-            BitmapData bmpData = b.LockBits(BoundsRect, ImageLockMode.WriteOnly,b.PixelFormat);
+            BitmapData bmpData = b.LockBits(BoundsRect, ImageLockMode.WriteOnly, b.PixelFormat);
             IntPtr ptr = bmpData.Scan0;
 
             Random rnd = new();
@@ -31,7 +30,7 @@ namespace BAVCL.Plotting
 
             // fill in rgbValues
             Marshal.Copy(arr, 0, ptr, arr.Length);
-            b.UnlockBits(bmpData); 
+            b.UnlockBits(bmpData);
             b.Save(@"C:\Users\marce\source\repos\DataScience\DataScience\Plotting\Saved Plots\noise.raw", ImageFormat.Bmp);
         }
 
@@ -46,12 +45,12 @@ namespace BAVCL.Plotting
             IntPtr ptr = bmpData.Scan0;
 
 
-            float[] p1 = new float[2] { 10, 10 };
-            float[] p2 = new float[2] { 500, 500 };
+            float[] p1 = [10, 10];
+            float[] p2 = [500, 500];
 
             float m = (p2[1] - p1[1]) / (p2[0] - p1[0]);
 
-            GPU gpu = new();
+            GPU gpu = GPUManager.Default;
             float[] Data = new float[width * height * 4];
             Array.Fill(Data, 255);
 
@@ -64,14 +63,14 @@ namespace BAVCL.Plotting
             byte add = (byte)(min < 0 ? -min : 0);
 
             byte[] arr = new byte[width * height * 4];
-            for (int i = 0, j=0; i < arr.Length; i+=4,j++)
+            for (int i = 0, j = 0; i < arr.Length; i += 4, j++)
             {
-                arr[i] = (byte)(((byte)Data[i]) * Convert.ToByte(!idxs.Contains(j+add)));
-                arr[i+1] = (byte)(((byte)Data[i+1]) * Convert.ToByte(!idxs.Contains(j + add)));
-                arr[i+2] = (byte)(((byte)Data[i+2]) * Convert.ToByte(!idxs.Contains(j + add)));
-                arr[i+3] = (byte)(((byte)Data[i+3]) * Convert.ToByte(!idxs.Contains(j + add)));
+                arr[i] = (byte)(((byte)Data[i]) * Convert.ToByte(!idxs.Contains(j + add)));
+                arr[i + 1] = (byte)(((byte)Data[i + 1]) * Convert.ToByte(!idxs.Contains(j + add)));
+                arr[i + 2] = (byte)(((byte)Data[i + 2]) * Convert.ToByte(!idxs.Contains(j + add)));
+                arr[i + 3] = (byte)(((byte)Data[i + 3]) * Convert.ToByte(!idxs.Contains(j + add)));
             }
-            
+
 
             // fill in rgbValues
             Marshal.Copy(arr, 0, ptr, arr.Length);

--- a/BAVCL/Services/GPUService.cs
+++ b/BAVCL/Services/GPUService.cs
@@ -23,20 +23,7 @@ public static class GPUManager
     };
     public static Context Context => _context.Value;
     public static bool IsInitialized => _context.IsValueCreated;
-    public static GPU Default
-    {
-        get
-        {
-            if (_defaultGPU == null)
-            {
-                lock (_lock)
-                {
-                    _defaultGPU = GetGPU();
-                }
-            }
-            return _defaultGPU;
-        }
-    }
+    public static GPU Default => _defaultGPU ??= GetGPU();
     internal static Accelerator GetPreferedAccelerator(bool forceCPU)
     {
         var devices = Context.Devices;
@@ -73,8 +60,13 @@ public static class GPUManager
         return preferedAccelerator.CreateAccelerator(Context);
     }
 
-    public static GPU GetGPU(float memorycap = 0.8f, bool forceCPU = false) =>
-        GetGPU<LRU>(memorycap, forceCPU);
+    public static GPU GetGPU(float memorycap = 0.8f, bool forceCPU = false)
+    {
+        lock (_lock)
+        {
+            return GetGPU<LRU>(memorycap, forceCPU);
+        }
+    }
     public static GPU GetGPU<TMem>(float memorycap = 0.8f, bool forceCPU = false) where TMem : IMemoryManager, new()
     {
         var accelerator = GetPreferedAccelerator(forceCPU);

--- a/BAVCL/Services/GPUService.cs
+++ b/BAVCL/Services/GPUService.cs
@@ -70,18 +70,23 @@ public static class GPUManager
         return preferedAccelerator.CreateAccelerator(Context);
     }
 
-    public static GPU GetGPU(float memorycap = 0.8f, bool forceCPU = false)
+    public static GPU GetGPU(float memoryCap = 0.8f, bool forceCPU = false)
     {
         Console.WriteLine("Getting GPU...");
-        return GetGPU<LRU>(memorycap, forceCPU);
+        return GetGPU<LRU>(memoryCap, forceCPU);
     }
-    public static GPU GetGPU<TMem>(float memorycap = 0.8f, bool forceCPU = false) where TMem : IMemoryManager, new()
+    public static GPU GetGPU<TMem>(float memoryCap = 0.8f, bool forceCPU = false) where TMem : IMemoryManager, new()
     {
+        if (memoryCap <= 0f || memoryCap >= 1f)
+            throw new Exception($"Memory Cap CANNOT be less than 0 or more than 1. Recieved {memoryCap}");
+
         var accelerator = GetPreferedAccelerator(forceCPU);
         Console.WriteLine($"Device loaded: {accelerator.Name}");
 
-        var memoryManager = new TMem();
-        memoryManager.LimitAccessibleMemory(accelerator.MemorySize, memorycap);
+        var memoryManager = new TMem()
+        {
+            AvailableMemory = (long)Math.Round(accelerator.MemorySize * memoryCap)
+        };
 
         var gpu = new GPU(accelerator, memoryManager);
 

--- a/BAVCL/Services/GPUService.cs
+++ b/BAVCL/Services/GPUService.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using BAVCL.Core;
+using BAVCL.Core.Interfaces;
+using ILGPU;
+using ILGPU.Runtime;
+
+namespace BAVCL.Services;
+
+public static class GPUManager
+{
+    private static readonly object _lock = new();
+    private static Lazy<Context> _context = new(
+        () => Context.Create(builder => builder.Default().EnableAlgorithms())
+    );
+    private static GPU? _defaultGPU = null;
+
+    private static Dictionary<AcceleratorType, int> _acceleratorPrefOrder = new()
+    {
+        { AcceleratorType.Cuda, 2 },
+        { AcceleratorType.OpenCL, 1 },
+        { AcceleratorType.CPU, 0 }
+    };
+    public static Context Context => _context.Value;
+    public static bool IsInitialized => _context.IsValueCreated;
+    public static GPU Default
+    {
+        get
+        {
+            if (_defaultGPU == null)
+            {
+                lock (_lock)
+                {
+                    _defaultGPU = GetGPU();
+                }
+            }
+            return _defaultGPU;
+        }
+    }
+    internal static Accelerator GetPreferedAccelerator(bool forceCPU)
+    {
+        var devices = Context.Devices;
+
+        if (devices.Length == 0) throw new Exception("No Accelerators");
+
+        Device? preferedAccelerator = null;
+        for (int i = 0; i < devices.Length; i++)
+        {
+            if (forceCPU && devices[i].AcceleratorType == AcceleratorType.CPU)
+                return devices[i].CreateAccelerator(Context);
+
+            preferedAccelerator ??= devices[i];
+
+            if (_acceleratorPrefOrder.TryGetValue(preferedAccelerator.AcceleratorType, out int Prefpriority))
+                if (_acceleratorPrefOrder.TryGetValue(devices[i].AcceleratorType, out int Devicepriority))
+                {
+                    if (Devicepriority > Prefpriority)
+                    {
+                        preferedAccelerator = devices[i];
+                        continue;
+                    }
+
+                    if (devices[i].MaxConstantMemory > preferedAccelerator.MaxConstantMemory)
+                    {
+                        preferedAccelerator = devices[i];
+                        continue;
+                    }
+                }
+        }
+        if (preferedAccelerator == null)
+            throw new Exception("No suitable accelerator found.");
+
+        return preferedAccelerator.CreateAccelerator(Context);
+    }
+
+    public static GPU GetGPU(float memorycap = 0.8f, bool forceCPU = false) =>
+        GetGPU<LRU>(memorycap, forceCPU);
+    public static GPU GetGPU<TMem>(float memorycap = 0.8f, bool forceCPU = false) where TMem : IMemoryManager, new()
+    {
+        var accelerator = GetPreferedAccelerator(forceCPU);
+        Console.WriteLine($"Device loaded: {accelerator.Name}");
+
+        var memoryManager = new TMem();
+        memoryManager.LimitAccessibleMemory(accelerator.MemorySize, memorycap);
+
+        var gpu = new GPU(accelerator, memoryManager);
+
+        gpu.LoadKernels();
+
+        return gpu;
+    }
+}

--- a/Testing Console/Benchmark.cs
+++ b/Testing Console/Benchmark.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using ILGPU;
 using BAVCL.Experimental;
 using ILGPU.Runtime;
+using BAVCL.Services;
 
 namespace Testing_Console
 {
@@ -16,17 +17,17 @@ namespace Testing_Console
 	public class Benchmark
 	{
 
-		[Params(10, 100, 1000,10000)]
+		[Params(10, 100, 1000, 10000)]
 		public int datalength;
 
-		GPU gpu;
-		float[] data;
-		Random rnd;
+		GPU gpu = null!;
+		float[] data = null!;
+		Random rnd = null!;
 
 		[GlobalSetup]
 		public void GlobalSetup()
 		{
-			gpu = new();
+			gpu = GPUManager.Default;
 			rnd = new(4522156);
 			data = new float[datalength];
 			for (int i = 0; i < data.Length; i++)
@@ -36,7 +37,7 @@ namespace Testing_Console
 		[Benchmark]
 		public void Create()
 		{
-			Vector newVec = new Vector(gpu, data);
+			Vector newVec = new(gpu, data);
 		}
 
 		//[Params(2, 8, 16, 49, 100, 64, 256, 529, 165518, 5131, 123, 71645, 12.1518f)]

--- a/Testing Console/Program.cs
+++ b/Testing Console/Program.cs
@@ -2,8 +2,9 @@ using System;
 using BAVCL;
 using BAVCL.Core;
 using BAVCL.Geometric;
+using BAVCL.Services;
 
-GPU gpu = new();
+GPU gpu = GPUManager.Default;
 Vector3 vec = new(gpu, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
 Vector3 vec2 = new(gpu, [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5]);
 

--- a/Testing Console/Testing Console.csproj
+++ b/Testing Console/Testing Console.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Testing_Console</RootNamespace>
+    <Nullable>enable</Nullable>
     <StartupObject></StartupObject>
   </PropertyGroup>
 


### PR DESCRIPTION
Added gpu manager
Refactor code to consistently use the `Gpu` property instead of `gpu` variable. Enable nullable reference types in the project files and clean up the project structure. Introduce a new exception for uncompiled kernels.